### PR TITLE
Add filtering by process and module name to 'helper' executable

### DIFF
--- a/helper/main.cc
+++ b/helper/main.cc
@@ -1,11 +1,13 @@
 // clang-format off
+#include <cstddef>
 #include <windows.h>
 #include <psapi.h>
 #include <stdio.h>
 #include <tchar.h>
 // clang-format on
 
-void PrintProcessInfo(DWORD processID) {
+void PrintProcessInfo(DWORD processID, char *expected_process_name,
+                      char *expected_module_name) {
   HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
                                 FALSE, processID);
 
@@ -13,15 +15,28 @@ void PrintProcessInfo(DWORD processID) {
     HMODULE hMods[1024];
     DWORD cbNeeded;
 
-    if (EnumProcessModulesEx(hProcess, hMods, sizeof(hMods), &cbNeeded, LIST_MODULES_ALL)) {
+    if (EnumProcessModulesEx(hProcess, hMods, sizeof(hMods), &cbNeeded,
+                             LIST_MODULES_ALL)) {
       TCHAR szProcessName[MAX_PATH] = TEXT("<unknown>");
       GetModuleBaseName(hProcess, hMods[0], szProcessName,
                         sizeof(szProcessName) / sizeof(TCHAR));
+
+      if (expected_process_name &&
+          strcmp(szProcessName, expected_process_name) != 0) {
+        CloseHandle(hProcess);
+        return;
+      }
 
       for (DWORD i = 1; i < cbNeeded / sizeof(HMODULE); ++i) {
         TCHAR szModuleName[MAX_PATH] = TEXT("<unknown>");
         GetModuleBaseName(hProcess, hMods[i], szModuleName,
                           sizeof(szModuleName) / sizeof(TCHAR));
+
+        if (expected_module_name) {
+          if (strcmp(szModuleName, expected_module_name) != 0)
+            continue;
+        }
+
         _tprintf(TEXT("%lu:%lu:%s:%s\n"), processID, i, szProcessName,
                  szModuleName);
       }
@@ -31,18 +46,28 @@ void PrintProcessInfo(DWORD processID) {
   CloseHandle(hProcess);
 }
 
-int main(void) {
+int main(int argc, char *argv[]) {
   DWORD aProcesses[1024], cbNeeded, cProcesses;
 
   if (!EnumProcesses(aProcesses, sizeof(aProcesses), &cbNeeded)) {
     return 1;
   }
 
+  char* expected_process = NULL;
+  char* expected_module = NULL;
+  for (int i = 0; i < argc; i++) {
+    if (strcmp(argv[i], "processName=") >= 0) {
+      expected_process = &argv[i][12];
+    } else if (strcmp(argv[i], "moduleName=") >= 0) {
+      expected_module = &argv[i][11];
+    }
+  }
+
   cProcesses = cbNeeded / sizeof(DWORD);
 
   for (DWORD i = 0; i < cProcesses; i++) {
     if (aProcesses[i] != 0) {
-      PrintProcessInfo(aProcesses[i]);
+      PrintProcessInfo(aProcesses[i], expected_process, expected_module);
     }
   }
 

--- a/helper/main.cc
+++ b/helper/main.cc
@@ -22,7 +22,7 @@ void PrintProcessInfo(DWORD processID, TCHAR *expected_process_name,
                         sizeof(szProcessName) / sizeof(TCHAR));
 
       if (expected_process_name &&
-          _tcscmp(szProcessName, expected_process_name) != 0) {
+          _tcsicmp(szProcessName, expected_process_name) != 0) {
         CloseHandle(hProcess);
         return;
       }
@@ -33,7 +33,7 @@ void PrintProcessInfo(DWORD processID, TCHAR *expected_process_name,
                           sizeof(szModuleName) / sizeof(TCHAR));
 
         if (expected_module_name) {
-          if (_tcscmp(szModuleName, expected_module_name) != 0)
+          if (_tcsicmp(szModuleName, expected_module_name) != 0)
             continue;
         }
 

--- a/helper/main.cc
+++ b/helper/main.cc
@@ -6,8 +6,8 @@
 #include <tchar.h>
 // clang-format on
 
-void PrintProcessInfo(DWORD processID, char *expected_process_name,
-                      char *expected_module_name) {
+void PrintProcessInfo(DWORD processID, TCHAR *expected_process_name,
+                      TCHAR *expected_module_name) {
   HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
                                 FALSE, processID);
 
@@ -22,7 +22,7 @@ void PrintProcessInfo(DWORD processID, char *expected_process_name,
                         sizeof(szProcessName) / sizeof(TCHAR));
 
       if (expected_process_name &&
-          strcmp(szProcessName, expected_process_name) != 0) {
+          _tcscmp(szProcessName, expected_process_name) != 0) {
         CloseHandle(hProcess);
         return;
       }
@@ -33,7 +33,7 @@ void PrintProcessInfo(DWORD processID, char *expected_process_name,
                           sizeof(szModuleName) / sizeof(TCHAR));
 
         if (expected_module_name) {
-          if (strcmp(szModuleName, expected_module_name) != 0)
+          if (_tcscmp(szModuleName, expected_module_name) != 0)
             continue;
         }
 
@@ -46,19 +46,19 @@ void PrintProcessInfo(DWORD processID, char *expected_process_name,
   CloseHandle(hProcess);
 }
 
-int main(int argc, char *argv[]) {
+int _tmain(int argc, TCHAR *argv[]) {
   DWORD aProcesses[1024], cbNeeded, cProcesses;
 
   if (!EnumProcesses(aProcesses, sizeof(aProcesses), &cbNeeded)) {
     return 1;
   }
 
-  char* expected_process = NULL;
-  char* expected_module = NULL;
+  TCHAR* expected_process = NULL;
+  TCHAR* expected_module = NULL;
   for (int i = 0; i < argc; i++) {
-    if (strcmp(argv[i], "processName=") >= 0) {
+    if (_tcscmp(argv[i], TEXT("processName=")) >= 0) {
       expected_process = &argv[i][12];
-    } else if (strcmp(argv[i], "moduleName=") >= 0) {
+    } else if (_tcscmp(argv[i], TEXT("moduleName=")) >= 0) {
       expected_module = &argv[i][11];
     }
   }

--- a/helper/main.cc
+++ b/helper/main.cc
@@ -55,10 +55,10 @@ int _tmain(int argc, TCHAR *argv[]) {
 
   TCHAR* expected_process = NULL;
   TCHAR* expected_module = NULL;
-  for (int i = 0; i < argc; i++) {
-    if (_tcscmp(argv[i], TEXT("processName=")) >= 0) {
+  for (int i = 1; i < argc; i++) {
+    if (_tcsncmp(argv[i], TEXT("processName="), 12) == 0) {
       expected_process = &argv[i][12];
-    } else if (_tcscmp(argv[i], TEXT("moduleName=")) >= 0) {
+    } else if (_tcsncmp(argv[i], TEXT("moduleName="), 11) == 0) {
       expected_module = &argv[i][11];
     }
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,8 +25,17 @@ type ModuleInfo = {
 	moduleName: string
 };
 
-async function enumerateProcesses(helperPath: string): Promise<ModuleInfo[]> {
-	const output = await execFileAsync(helperPath, []);
+type HelperOptions =  { processName?: string, moduleName?: string };
+
+async function enumerateProcesses(helperPath: string, options: HelperOptions): Promise<ModuleInfo[]> {
+	let args = [];
+	if (options.processName) {
+		args.push("processName=" + options.processName);
+	}
+	if (options.moduleName) {
+		args.push("moduleName=" + options.moduleName);
+	}
+	const output = await execFileAsync(helperPath, args);
 	const lines = output.split('\n');
 
 	return lines.map((line) => {
@@ -43,8 +52,8 @@ async function enumerateProcesses(helperPath: string): Promise<ModuleInfo[]> {
 
 const timeout = (ms: number) => new Promise(res => setTimeout(res, ms));
 
-async function getMatchingProcesses(helperPath: string, options: { processName?: string, moduleName?: string }): Promise<ModuleInfo[]> {
-	const moduleInfos = await enumerateProcesses(helperPath);
+async function getMatchingProcesses(helperPath: string, options: HelperOptions): Promise<ModuleInfo[]> {
+	const moduleInfos = await enumerateProcesses(helperPath, options);
 
 	if (options.moduleName === "ntdll.dll") {
 		// everybody links to ntdll.dll, therefore remove the filter


### PR DESCRIPTION
Hi, I found that this took a very long time to actually locate and attach to any given process, mostly because it was printing out the details of every single process and module currently running.

I've added the ability to find (exactly) matching process names / module names to the 'helper' executable so it doesn't have to print as much text.